### PR TITLE
Update test_image.py

### DIFF
--- a/test_image.py
+++ b/test_image.py
@@ -107,7 +107,7 @@ with tf.Graph().as_default():
                     emb_array[0, :] = sess.run(embeddings, feed_dict=feed_dict)
                     predictions = model.predict_proba(emb_array)
                     print(predictions)
-                    best_class_indices = np.argmax(predictions, axis=1)
+                    best_class_indices = np.argmin(predictions, axis=1)
                     # print(best_class_indices)
                     best_class_probabilities = predictions[np.arange(len(best_class_indices)), best_class_indices]
                     print(best_class_probabilities)


### PR DESCRIPTION
Fixed misinterpretation of results. 
argmin should be used instead of argmax to find the best match (instead of the worst match)

Seems to be a bug that only shows it's face in the case where there is only 1 image used per person (the above does not fix it). I'll close the pull request.